### PR TITLE
adjust collat_out decimals to decimals of comparing FRAX_amount

### DIFF
--- a/contracts/Frax/Pools/FraxPoolvAMM.sol
+++ b/contracts/Frax/Pools/FraxPoolvAMM.sol
@@ -417,7 +417,7 @@ contract FraxPoolvAMM is AccessControl {
         // Sanity check to make sure the collat amount is close to the expected amount from the FRAX input
         // Useful in case of a sandwich attack or some other fault with the virtual reserves
         // Assumes $1 collateral (USDC, USDT, DAI, etc)
-        require(collat_out <= FRAX_amount.mul(global_collateral_ratio).mul(uint256(1e6).add(max_drift_band)).div(1e12), "[max_drift_band] Too much collateral being released");
+        require(collat_out.mul(10 ** missing_decimals) <= FRAX_amount.mul(global_collateral_ratio).mul(uint256(1e6).add(max_drift_band)).div(1e12), "[max_drift_band] Too much collateral being released");
         
         redeemCollateralBalances[msg.sender] = redeemCollateralBalances[msg.sender].add(collat_out);
         unclaimedPoolCollateral = unclaimedPoolCollateral.add(collat_out);


### PR DESCRIPTION
The collat_out decimals are truncated from 18 to 6 (or however many decimals the collateral has) at the beginning of this function and need to be raised back up to 18 decimals to perform the comparison against the expected FRAX_amount.