### PR TITLE
Simplified onlyWhitelist, returned twamm tests to original error tolerance

### DIFF
--- a/src/hardhat/contracts/FPI/TWAMM.sol
+++ b/src/hardhat/contracts/FPI/TWAMM.sol
@@ -90,8 +90,7 @@ contract TWAMM is ERC20 {
 
     // EC5: Whitelist has not been disabled
     modifier onlyWhitelist() {
-        if(!whitelistDisabled)
-            require(msg.sender == owner_address, 'EC5');
+        require(whitelistDisabled || msg.sender == owner_address, 'EC5');
         _;
     }
 

--- a/src/hardhat/test/twamm-test.js
+++ b/src/hardhat/test/twamm-test.js
@@ -180,7 +180,7 @@ describe("TWAMM", function () {
                 
                 //move blocks forward, and execute virtual orders
                 await mineBlocks(3 * blockInterval)
-                await twamm.connect(addr1).executeVirtualOrders();
+                await twamm.executeVirtualOrders();
 
                 //withdraw proceeds 
                 const beforeBalanceB = await tokenB.balanceOf(addr1.address);
@@ -209,7 +209,7 @@ describe("TWAMM", function () {
 
                 //move blocks forward, and execute virtual orders
                 await mineBlocks(3 * blockInterval)
-                await twamm.connect(addr1).executeVirtualOrders();
+                await twamm.executeVirtualOrders();
 
                 //withdraw proceeds 
                 await twamm.connect(addr1).withdrawProceedsFromLongTermSwap(0);
@@ -261,7 +261,7 @@ describe("TWAMM", function () {
 
                 //move blocks forward, and execute virtual orders
                 await mineBlocks(22 * blockInterval)
-                await twamm.connect(addr1).executeVirtualOrders();
+                await twamm.executeVirtualOrders();
 
                 //withdraw proceeds 
                 await twamm.connect(addr1).withdrawProceedsFromLongTermSwap(0);
@@ -273,12 +273,12 @@ describe("TWAMM", function () {
                 const finalAReserveActual = (await twamm.tokenAReserves());
                 const finalBReserveActual = (await twamm.tokenBReserves());
 
-                //expect results to be close to calculation
-                expect(finalAReserveActual.toNumber()).to.be.closeTo(finalAReserveExpected, finalAReserveExpected/99);
-                expect(finalBReserveActual.toNumber()).to.be.closeTo(finalBReserveExpected, finalBReserveExpected/99);
+                //expect results to be within 1% of calculation
+                expect(finalAReserveActual.toNumber()).to.be.closeTo(finalAReserveExpected, finalAReserveExpected/100);
+                expect(finalBReserveActual.toNumber()).to.be.closeTo(finalBReserveExpected, finalBReserveExpected/100);
 
-                expect(amountABought.toNumber()).to.be.closeTo(tokenAOut, tokenAOut/80);
-                expect(amountBBought.toNumber()).to.be.closeTo(tokenBOut, tokenBOut/80);
+                expect(amountABought.toNumber()).to.be.closeTo(tokenAOut, tokenAOut/100);
+                expect(amountBBought.toNumber()).to.be.closeTo(tokenBOut, tokenBOut/100);
             });
 
             it("Multiple orders in both pools work as expected", async function () {
@@ -299,7 +299,7 @@ describe("TWAMM", function () {
 
                 //move blocks forward, and execute virtual orders
                 await mineBlocks(6 * blockInterval)
-                await twamm.connect(addr1).executeVirtualOrders();
+                await twamm.executeVirtualOrders();
 
                 //withdraw proceeds 
                 await twamm.connect(addr1).withdrawProceedsFromLongTermSwap(0);
@@ -331,7 +331,7 @@ describe("TWAMM", function () {
 
                 //move blocks forward, and execute virtual orders
                 await mineBlocks(3 * blockInterval)
-                await twamm.connect(addr1).executeVirtualOrders();
+                await twamm.executeVirtualOrders();
 
                 //withdraw proceeds 
                 await twamm.connect(addr1).withdrawProceedsFromLongTermSwap(0);
@@ -342,7 +342,7 @@ describe("TWAMM", function () {
 
                 //pool is balanced, and both orders execute same amount in opposite directions,
                 //so we expect final balances to be roughly equal
-                expect(amountABought).to.be.closeTo(amountBBought, amountIn / 80)          
+                expect(amountABought).to.be.closeTo(amountBBought, amountIn / 100)          
             });
         });
 


### PR DESCRIPTION
Discrepancy in balances was due to addr1 calling executeVirtualOrders()