### PR TITLE
OHMV2 AMO

### DIFF
--- a/src/hardhat/contracts/Misc_AMOs/olympus/V2/IBondDepository.sol
+++ b/src/hardhat/contracts/Misc_AMOs/olympus/V2/IBondDepository.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.7.5;
+
+import "./IERC20.sol";
+import "./INoteKeeper.sol";
+
+interface IBondDepository is INoteKeeper {
+
+  // Info about each type of market
+  struct Market {
+    uint256 capacity; // capacity remaining
+    IERC20 quoteToken; // token to accept as payment
+    bool capacityInQuote; // capacity limit is in payment token (true) or in OHM (false, default)
+    uint64 totalDebt; // total debt from market
+    uint64 maxPayout; // max tokens in/out (determined by capacityInQuote false/true, respectively)
+    uint64 sold; // base tokens out
+    uint256 purchased; // quote tokens in
+  }
+
+  // Info for creating new markets
+  struct Terms {
+    bool fixedTerm; // fixed term or fixed expiration
+    uint64 controlVariable; // scaling variable for price
+    uint48 vesting; // length of time from deposit to maturity if fixed-term
+    uint48 conclusion; // timestamp when market no longer offered (doubles as time when market matures if fixed-expiry)
+    uint64 maxDebt; // 9 decimal debt maximum in OHM
+  }
+
+  // Additional info about market.
+  struct Metadata {
+    uint48 lastTune; // last timestamp when control variable was tuned
+    uint48 lastDecay; // last timestamp when market was created and debt was decayed
+    uint48 length; // time from creation to conclusion. used as speed to decay debt.
+    uint48 depositInterval; // target frequency of deposits
+    uint48 tuneInterval; // frequency of tuning
+    uint8 quoteDecimals; // decimals of quote token
+  }
+
+  // Control variable adjustment data
+  struct Adjustment {
+    uint64 change;
+    uint48 lastAdjustment;
+    uint48 timeToAdjusted;
+    bool active;
+  }
+
+
+  /**
+   * @notice deposit market
+   * @param _bid uint256
+   * @param _amount uint256
+   * @param _maxPrice uint256
+   * @param _user address
+   * @param _referral address
+   * @return payout_ uint256
+   * @return expiry_ uint256
+   * @return index_ uint256
+   */
+  function deposit(
+    uint256 _bid,
+    uint256 _amount,
+    uint256 _maxPrice,
+    address _user,
+    address _referral
+  ) external returns (
+    uint256 payout_, 
+    uint256 expiry_,
+    uint256 index_
+  );
+
+  function create (
+    IERC20 _quoteToken, // token used to deposit
+    uint256[3] memory _market, // [capacity, initial price]
+    bool[2] memory _booleans, // [capacity in quote, fixed term]
+    uint256[2] memory _terms, // [vesting, conclusion]
+    uint32[2] memory _intervals // [deposit interval, tune interval]
+  ) external returns (uint256 id_);
+  function close(uint256 _id) external;
+
+  function isLive(uint256 _bid) external view returns (bool);
+  function liveMarkets() external view returns (uint256[] memory);
+  function liveMarketsFor(address _quoteToken) external view returns (uint256[] memory);
+  function payoutFor(uint256 _amount, uint256 _bid) external view returns (uint256);
+  function marketPrice(uint256 _bid) external view returns (uint256);
+  function currentDebt(uint256 _bid) external view returns (uint256);
+  function debtRatio(uint256 _bid) external view returns (uint256);
+  function debtDecay(uint256 _bid) external view returns (uint64);
+}

--- a/src/hardhat/contracts/Misc_AMOs/olympus/V2/INoteKeeper.sol
+++ b/src/hardhat/contracts/Misc_AMOs/olympus/V2/INoteKeeper.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.7.5;
+
+interface INoteKeeper {
+  // Info for market note
+  struct Note {
+    uint256 payout; // gOHM remaining to be paid
+    uint48 created; // time market was created
+    uint48 matured; // timestamp when market is matured
+    uint48 redeemed; // time market was redeemed
+    uint48 marketID; // market ID of deposit. uint48 to avoid adding a slot.
+  }
+
+  function notes(address _user) external view returns (Note[] memory);
+
+  function redeem(address _user, uint256[] memory _indexes, bool _sendgOHM) external returns (uint256);
+  function redeemAll(address _user, bool _sendgOHM) external returns (uint256);
+  function pushNote(address to, uint256 index) external;
+  function pullNote(address from, uint256 index) external returns (uint256 newIndex_);
+
+  function indexesFor(address _user) external view returns (uint256[] memory);
+  function pendingFor(address _user, uint256 _index) external view returns (uint256 payout_, bool matured_);
+}

--- a/src/hardhat/contracts/Misc_AMOs/olympus/V2/IgOHM.sol
+++ b/src/hardhat/contracts/Misc_AMOs/olympus/V2/IgOHM.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.7.5;
+
+import "./IERC20.sol";
+
+interface IgOHM is IERC20 {
+  function mint(address _to, uint256 _amount) external;
+
+  function burn(address _from, uint256 _amount) external;
+
+  function index() external view returns (uint256);
+
+  function balanceFrom(uint256 _amount) external view returns (uint256);
+
+  function balanceTo(uint256 _amount) external view returns (uint256);
+
+  function migrate( address _staking, address _sOHM ) external;
+}

--- a/src/hardhat/contracts/Misc_AMOs/olympus/V2/OHM_AMO.sol
+++ b/src/hardhat/contracts/Misc_AMOs/olympus/V2/OHM_AMO.sol
@@ -1,0 +1,410 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.11;
+
+// ====================================================================
+// |     ______                   _______                             |
+// |    / _____________ __  __   / ____(_____  ____ _____  ________   |
+// |   / /_  / ___/ __ `| |/_/  / /_  / / __ \/ __ `/ __ \/ ___/ _ \  |
+// |  / __/ / /  / /_/ _>  <   / __/ / / / / / /_/ / / / / /__/  __/  |
+// | /_/   /_/   \__,_/_/|_|  /_/   /_/_/ /_/\__,_/_/ /_/\___/\___/   |
+// |                                                                  |
+// ====================================================================
+// ============================== OHM_AMO =============================
+// ====================================================================
+// Frax Finance: https://github.com/FraxFinance
+
+// Primary Author(s)
+// Travis Moore: https://github.com/FortisFortuna
+
+// Reviewer(s) / Contributor(s)
+// Jason Huan: https://github.com/jasonhuan
+// Sam Kazemian: https://github.com/samkazemian
+
+import ".../Math/SafeMath.sol";
+import ".../FXS/FXS.sol";
+import ".../Frax/Frax.sol";
+import ".../ERC20/ERC20.sol";
+import ".../ERC20/Variants/Comp.sol";
+import ".../Frax/Pools/FraxPool.sol";
+import ".../Staking/Owned.sol";
+import '.../Uniswap/TransferHelper.sol';
+import '.../Uniswap/UniswapV2Router02_Modified.sol';
+import '.../Uniswap/UniswapV2Pair.sol';
+import ".../Proxy/Initializable.sol";
+import ".../Staking/Owned_Proxy.sol";
+import "./IBondDepository.sol";
+import "./IgOHM.sol";
+import "./IOlympusStaking.sol";
+
+// The AMO needs to have 
+// 1) Mint FRAX -> Bond (coming next week) -> Collect OHM rewards
+// 2) Stake OHM and be able to collect rewards and also withdraw the staked OHM
+// 3) Collect OHM rewards and send to custodian
+// 4) Sell OHM for FRAX
+
+contract OHM_AMO is Initializable, Owned_Proxy {
+    using SafeMath for uint256;
+
+    /* ========== STATE VARIABLES ========== */
+
+    // FRAX related
+    FRAXStablecoin private FRAX;
+    FraxPool private pool;
+    address public pool_address;
+    address public timelock_address;
+    address public custodian_address;
+
+    // Collateral related
+    address public collateral_address;
+
+    // Uniswap related
+    IUniswapV2Router02 private UniRouterV2;
+    UniswapV2Pair private UNI_OHM_FRAX_PAIR;
+    address payable public UNISWAP_ROUTER_ADDRESS;
+
+    // OHM related
+    IERC20 private OHM;
+    IsOHM private sOHM;
+    IgOHM private gOHM;
+    IOlympusStaking private olympusStaking;
+    IOlympusBondDepository private bondDepository;
+
+    // Precision
+    uint256 private missing_decimals_collat;
+    uint256 private missing_decimals_ohm;
+    uint256 private PRICE_PRECISION;
+
+    // Max amount of FRAX this contract mint
+    int256 public mint_cap;
+
+    // Minimum collateral ratio needed for new FRAX minting
+    uint256 public min_cr;
+
+    // Amount the contract borrowed
+    int256 public minted_sum_historical;
+    int256 public burned_sum_historical;
+
+    // Collateral balance related
+    bool public override_collat_balance;
+    uint256 public override_collat_balance_amount;
+    
+    /* ========== MODIFIERS ========== */
+
+    modifier onlyByOwnerOrGovernance() {
+        require(msg.sender == timelock_address || msg.sender == owner, "You are not the owner or the governance timelock");
+        _;
+    }
+
+    modifier onlyCustodian() {
+        require(msg.sender == custodian_address, "You are not the rewards custodian");
+        _;
+    }
+
+    /* ========== CONSTRUCTOR ========== */
+    
+    function initialize(
+        address _frax_contract_address,
+        address _pool_address,
+        address _collateral_address,
+        address _creator_address,
+        address _custodian_address,
+        address _timelock_address
+    ) public initializer {
+        owner = _creator_address;
+        FRAX = FRAXStablecoin(_frax_contract_address);
+        pool_address = _pool_address;
+        pool = FraxPool(_pool_address);
+        timelock_address = _timelock_address;
+        custodian_address = _custodian_address;
+        collateral_address = _collateral_address;
+
+        // Assignments (must be done in initializer, so assignment gets stored in proxy address's storage instead of implementation address's storage)
+        // Olympus
+        OHM = IERC20(0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5);
+        sOHM = IERC20(0x04906695d6d12cf5459975d7c3c03356e4ccd460);
+        gOHM = IgOHM(0x0ab87046fBb341D058F17CBC4c1133F25a20a52f);
+        olympusStaking = IOlympusStaking(0xb63cac384247597756545b500253ff8e607a8020);
+        bondDepository = IOlympusBondDepository(0x9025046c6fb25fb39e720d97a8fd881ed69a1ef6);
+
+        // Uniswap
+        UNISWAP_ROUTER_ADDRESS = payable(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
+        UniRouterV2 = IUniswapV2Router02(UNISWAP_ROUTER_ADDRESS);
+        UNI_OHM_FRAX_PAIR = UniswapV2Pair(0xb612c37688861f1f90761dc7f382c2af3a50cc39);
+
+        PRICE_PRECISION = 1e6;
+        missing_decimals_collat = 12;
+        missing_decimals_ohm = 9;
+
+        mint_cap = int256(2500000e18);
+        min_cr = 820000;
+        minted_sum_historical = 0;
+        burned_sum_historical = 0;
+
+        override_collat_balance = false;
+    }
+
+    /* ========== VIEWS ========== */
+
+    function showAllocations() public view returns (uint256[6] memory allocations) {
+        // All numbers given are in FRAX unless otherwise stated
+        // Call once to save gas
+        (uint256 spot_price_ohm_raw, ) = spotPriceOHM();
+
+        allocations[0] = FRAX.balanceOf(address(this)); // Unallocated FRAX
+        allocations[1] = OHM.balanceOf(address(this)).mul(spot_price_ohm_raw); // OHM
+        allocations[2] = sOHM.balanceOf(address(this)).mul(spot_price_ohm_raw); // sOHM
+        allocations[3] = gOHM.balanceFrom(gOHM.balanceOf(address(this)).mul(spot_price_ohm_raw)); // gOHM
+        allocations[4] = (bondDepository.pendingPayoutFor(address(this))).mul(spot_price_ohm_raw); // Claimable OHM from bonding
+    
+        uint256 sum_tally = 0;
+        for (uint i = 0; i < 4; i++){ 
+            if (allocations[i] > 0){
+                sum_tally = sum_tally.add(allocations[i]);
+            }
+        }
+
+        allocations[5] = sum_tally; // Total Staked
+    }
+
+    function showSOHMRewards() external view returns (uint256) {
+        return sOHM.balanceOf(address(this));
+    }
+
+    function showGOHMRewards() external view returns (uint256) {
+        return gOHM.balanceOf(address(this));
+    }
+
+    function spotPriceOHM() public view returns (uint256 frax_per_ohm_raw, uint256 frax_per_ohm) {
+        (uint256 reserve0, uint256 reserve1, ) = (UNI_OHM_FRAX_PAIR.getReserves());
+
+        // OHM = token0, FRAX = token1
+        frax_per_ohm_raw = reserve1.div(reserve0);
+        frax_per_ohm = reserve1.mul(PRICE_PRECISION).div(reserve0.mul(10 ** missing_decimals_ohm));
+    }
+
+    // In FRAX, can be negative
+    function mintedBalance() public view returns (int256) {
+        return minted_sum_historical - burned_sum_historical;
+    }
+
+    // In FRAX, can be negative
+    function accumulatedProfit() public view returns (int256) {
+        return int256(showAllocations()[4]) - mintedBalance();
+    }
+
+    /* ========== PUBLIC FUNCTIONS ========== */
+
+    // Needed for the Frax contract to function 
+    function collatDollarBalance() external view returns (uint256) {
+        // Needs to mimic the FraxPool value and return in E18
+        // Override is here in case of a brick on the Olympus side
+        if(override_collat_balance){
+            return override_collat_balance_amount;
+        }
+        else {
+            return (showAllocations()[4]);
+        }
+        
+    }
+
+    // This contract is essentially marked as a 'pool' so it can call OnlyPools functions like pool_mint and pool_burn_from
+    // on the main FRAX contract
+    function mintFRAXForInvestments(uint256 frax_amount) public onlyByOwnerOrGovernance {
+        int256 frax_amt_i256 = int256(frax_amount);
+
+        // Make sure you aren't minting more than the mint cap
+        require((mintedBalance() + frax_amt_i256) <= mint_cap, "Mint cap reached");
+        minted_sum_historical = minted_sum_historical + frax_amt_i256;
+
+        // Make sure the current CR isn't already too low
+        require (FRAX.global_collateral_ratio() > min_cr, "Collateral ratio is already too low");
+
+        // Make sure the FRAX minting wouldn't push the CR down too much
+        // This is also a sanity check for the int256 math
+        uint256 current_collateral_E18 = (FRAX.globalCollateralValue()).mul(10 ** missing_decimals_collat);
+        uint256 cur_frax_supply = FRAX.totalSupply();
+        uint256 new_frax_supply = cur_frax_supply.add(frax_amount);
+        uint256 new_cr = (current_collateral_E18.mul(PRICE_PRECISION)).div(new_frax_supply);
+        require (new_cr > min_cr, "Minting would cause collateral ratio to be too low");
+
+        // Mint the frax 
+        FRAX.pool_mint(address(this), frax_amount);
+    }
+
+    // Burn unneeded or excess FRAX
+    function burnFRAX(int256 frax_amount) public onlyByOwnerOrGovernance {
+        require(frax_amount > 0, "frax_amount must be positive");
+        FRAX.burn(uint256(frax_amount));
+        burned_sum_historical = burned_sum_historical + frax_amount;
+    }
+
+    /* ========== Olympus: Bonding ========== */
+
+    function bondFRAX(uint256 id, uint256 frax_amount, address frontEnd) public onlyByOwnerOrGovernance {
+        FRAX.approve(address(bondDepository), frax_amount);
+        bondDepository.deposit(id, frax_amount, bondDepository.marketPrice(id), address(this), frontEnd);
+    }
+
+    function redeemBondedFRAX(bool gOHM) public onlyByOwnerOrGovernance {
+        bondDepository.redeem(address(this), gOHM);
+    }
+
+    function note(uint256 index) public view returns (IBondDepository.Note memory) {
+        return bondDepository.notes(address(this))[index];
+    }
+
+    function noteIndexes() public view returns (uint256[] memory) {
+        return bondDepository.indexesFor(address(this));
+    }
+
+    // not sure if you want this or not
+    // let's you transfer the note to another address
+    // there is a pull method as well, but doesn't seem that appropriate to add here (feel free to though)
+    function pushNote(address to, uint256 index) public {
+        bondDepository.pushNote(to, index);
+    }
+
+    /* ========== Olympus: Staking ========== */
+
+    // OHM -> sOHM. E9
+    // Stake OHM for sOHM or gOHM (if sOHM bool true/false, respectively)
+    // claim bool distinguishes whether to claim immediately, if warmup is 0
+    function stakeOHM(uint256 ohm_amount, bool getSOHM, bool claim) public onlyByOwnerOrGovernance {
+        OHM.approve(address(olympusStaking), ohm_amount);
+        olympusStaking.stake(address(this), ohm_amount, getSOHM, claim);
+    }
+
+    // Claim the OHM
+    // bool sOHM is true to receive sOHM, false to receive gOHM
+    function claimOHM(bool getSOHM) public onlyByOwnerOrGovernance {
+        olympusStaking.claim(address(this), getSOHM);
+    }
+
+    // sOHM -> OHM. E9
+    // The contract is set up with a warmup period, where user has to stake for some number of epochs before they can 
+    // get the sOHM. If they unstake before then they only get the deposit.
+    // They earn during warmup period though just can't get rewards before it.
+    // rebase bool will trigger or not trigger the rebase if eligible (true unless issue)
+    // sOHM bool will unstake from sOHM or gOHM (if true or false, respectively)
+    function unstakeOHM(uint256 sohm_amount, bool rebase, bool fromSOHM) public onlyByOwnerOrGovernance {
+        sOHM.approve(address(olympusStaking), sohm_amount);
+        olympusStaking.unstake(address(this), sohm_amount, rebase, fromSOHM);
+    }
+
+    function wrapSOHM(uint256 sohm_amount) public onlyByOwnerOrGovernance {
+        sOHM.approve(address(olympusStaking), sohm_amount);
+        olympusStaking.wrap(address(this), sohm_amount);
+    }
+
+    function unwrapGOHM(uint256 gohm_amount) public onlyByOwnerOrGovernance {
+        olympusStaking.unwrap(address(this), gohm_amount);
+    }
+
+    // Forfeit takes back the OHM before the warmup is over
+    function forfeitOHM() public onlyByOwnerOrGovernance {
+        olympusStaking.forfeit();
+    }
+
+    // toggleDepositLock() prevents new stakes from being added to the address
+    // Anyone can stake for you and it delays the warmup so if someone were to do so maliciously 
+    // you'd just toggle that until warmup is done.
+    function toggleStakingLock() public onlyByOwnerOrGovernance {
+        olympusStaking.toggleLock();
+    }
+
+/*      to be implemented in V2.0.1 bond depository
+        prevents external address from redeeming bond for you
+    function toggleDepositoryLock() public onlyByOwnerOrGovernance {
+        bondDepository.lock();
+    }
+*/
+    /* ========== Swaps ========== */
+
+    // FRAX -> OHM. E18 and E9
+    function swapFRAXforOHM(uint256 frax_amount, uint256 min_ohm_out) external onlyByOwnerOrGovernance returns (uint256 ohm_spent, uint256 frax_received) {
+        // Approve the FRAX for the router
+        FRAX.approve(UNISWAP_ROUTER_ADDRESS, frax_amount);
+
+        address[] memory FRAX_OHM_PATH = new address[](2);
+        FRAX_OHM_PATH[0] = address(FRAX);
+        FRAX_OHM_PATH[1] = address(OHM);
+
+        // Buy some FRAX with OHM
+        (uint[] memory amounts) = UniRouterV2.swapExactTokensForTokens(
+            frax_amount,
+            min_ohm_out,
+            FRAX_OHM_PATH,
+            address(this),
+            2105300114 // Expiration: a long time from now
+        );
+        return (amounts[0], amounts[1]);
+    }
+
+    // OHM -> FRAX. E9 and E18
+    function swapOHMforFRAX(uint256 ohm_amount, uint256 min_frax_out) external onlyByOwnerOrGovernance returns (uint256 ohm_spent, uint256 frax_received) {
+        // Approve the OHM for the router
+        OHM.approve(UNISWAP_ROUTER_ADDRESS, ohm_amount);
+
+        address[] memory OHM_FRAX_PATH = new address[](2);
+        OHM_FRAX_PATH[0] = address(OHM);
+        OHM_FRAX_PATH[1] = address(FRAX);
+
+        // Buy some FRAX with OHM
+        (uint[] memory amounts) = UniRouterV2.swapExactTokensForTokens(
+            ohm_amount,
+            min_frax_out,
+            OHM_FRAX_PATH,
+            address(this),
+            2105300114 // Expiration: a long time from now
+        );
+        return (amounts[0], amounts[1]);
+    }
+
+    /* ========== Custodian ========== */
+
+    function withdrawRewards() public onlyCustodian {
+        OHM.transfer(custodian_address, OHM.balanceOf(address(this)));
+    }
+
+    /* ========== RESTRICTED FUNCTIONS ========== */
+
+    function setTimelock(address new_timelock) external onlyByOwnerOrGovernance {
+        require(new_timelock != address(0), "Timelock address cannot be 0");
+        timelock_address = new_timelock;
+    }
+
+    function setCustodian(address _custodian_address) external onlyByOwnerOrGovernance {
+        require(_custodian_address != address(0), "Custodian address cannot be 0");        
+        custodian_address = _custodian_address;
+    }
+
+    function setPool(address _pool_address) external onlyByOwnerOrGovernance {
+        pool_address = _pool_address;
+        pool = FraxPool(_pool_address);
+    }
+
+    function setOverrideCollatBalance(bool _state, uint256 _balance) external onlyByOwnerOrGovernance {
+        override_collat_balance = _state;
+        override_collat_balance_amount = _balance;
+    }
+
+    function setMintCap(int256 _mint_cap) external onlyByOwnerOrGovernance {
+        mint_cap = _mint_cap;
+    }
+
+    function setMinimumCollateralRatio(uint256 _min_cr) external onlyByOwnerOrGovernance {
+        min_cr = _min_cr;
+    }
+
+    function emergencyRecoverERC20(address tokenAddress, uint256 tokenAmount) external onlyByOwnerOrGovernance {
+        // Can only be triggered by owner or governance, not custodian
+        // Tokens are sent to the custodian, as a sort of safeguard
+
+        ERC20(tokenAddress).transfer(custodian_address, tokenAmount);
+        emit Recovered(tokenAddress, tokenAmount);
+    }
+
+    /* ========== EVENTS ========== */
+
+    event Recovered(address token, uint256 amount);
+}


### PR DESCRIPTION
edits previous OHM AMO contract to account for V2 changes

Changes contained to Olympus: Bonding and Olympus: Staking -- accounts for gOHM + interface changes.
Addl changes: showAllocations() -- added index for gOHM. Updated contract addresses.

Note that Depository may be upgraded to include lock() (logic is included and ready, something to keep in mind regarding speed of deployment). Bond depository address just needs to be updated to 2.0.1 for this, plus uncommenting toggleBondLock() function.

import callback having difficulties but this should be an easy fix