### PR TITLE
Use Memory Type Variable Instead of Storage Type Variable in Event to Save Gas

### DIFF
--- a/src/hardhat/contracts/ERC20/__CROSSCHAIN/AnyswapV4ERC20.sol
+++ b/src/hardhat/contracts/ERC20/__CROSSCHAIN/AnyswapV4ERC20.sol
@@ -225,7 +225,7 @@ contract AnyswapV4ERC20 is IAnyswapV3ERC20 {
         require(newVault != address(0), "AnyswapV3ERC20: address(0x0)");
         pendingVault = newVault;
         delayVault = block.timestamp + delay;
-        emit LogChangeVault(vault, pendingVault, delayVault);
+        emit LogChangeVault(vault, newVault, delayVault);
         return true;
     }
 
@@ -233,7 +233,7 @@ contract AnyswapV4ERC20 is IAnyswapV3ERC20 {
         require(newVault != address(0), "AnyswapV3ERC20: address(0x0)");
         pendingVault = newVault;
         delayVault = block.timestamp + delay;
-        emit LogChangeMPCOwner(vault, pendingVault, delayVault);
+        emit LogChangeMPCOwner(vault, newVault, delayVault);
         return true;
     }
 

--- a/src/hardhat/contracts/ERC20/__CROSSCHAIN/AnyswapV5ERC20.sol
+++ b/src/hardhat/contracts/ERC20/__CROSSCHAIN/AnyswapV5ERC20.sol
@@ -224,7 +224,7 @@ contract AnyswapV5ERC20 is IAnyswapV3ERC20 {
         require(newVault != address(0), "AnyswapV3ERC20: address(0x0)");
         pendingVault = newVault;
         delayVault = block.timestamp + delay;
-        emit LogChangeVault(vault, pendingVault, delayVault);
+        emit LogChangeVault(vault, newVault, delayVault);
         return true;
     }
 
@@ -232,7 +232,7 @@ contract AnyswapV5ERC20 is IAnyswapV3ERC20 {
         require(newVault != address(0), "AnyswapV3ERC20: address(0x0)");
         pendingVault = newVault;
         delayVault = block.timestamp + delay;
-        emit LogChangeMPCOwner(vault, pendingVault, delayVault);
+        emit LogChangeMPCOwner(vault, newVault, delayVault);
         return true;
     }
 

--- a/src/hardhat/contracts/ERC20/__CROSSCHAIN/celrFRAX.sol
+++ b/src/hardhat/contracts/ERC20/__CROSSCHAIN/celrFRAX.sol
@@ -112,7 +112,7 @@ contract celrFRAX is ERC20Virtual, Ownable {
 
     function updateBridge(address _bridge) external onlyOwner {
         bridge = _bridge;
-        emit BridgeUpdated(bridge);
+        emit BridgeUpdated(_bridge);
     }
 
     function decimals() public view virtual override returns (uint8) {

--- a/src/hardhat/contracts/ERC20/__CROSSCHAIN/celrFXS.sol
+++ b/src/hardhat/contracts/ERC20/__CROSSCHAIN/celrFXS.sol
@@ -112,7 +112,7 @@ contract celrFXS is ERC20Virtual, Ownable {
 
     function updateBridge(address _bridge) external onlyOwner {
         bridge = _bridge;
-        emit BridgeUpdated(bridge);
+        emit BridgeUpdated(_bridge);
     }
 
     function decimals() public view virtual override returns (uint8) {

--- a/src/hardhat/contracts/Staking/CommunalFarm.sol
+++ b/src/hardhat/contracts/Staking/CommunalFarm.sol
@@ -579,7 +579,7 @@ contract CommunalFarm is Owned, ReentrancyGuard {
     function setMultipliers(uint256 _lock_max_multiplier) external onlyByOwner {
         require(_lock_max_multiplier >= uint256(1e18), "Multiplier must be greater than or equal to 1e18");
         lock_max_multiplier = _lock_max_multiplier;
-        emit LockedStakeMaxMultiplierUpdated(lock_max_multiplier);
+        emit LockedStakeMaxMultiplierUpdated(_lock_max_multiplier);
     }
 
     function setLockedStakeTimeForMinAndMaxMultiplier(uint256 _lock_time_for_max_multiplier, uint256 _lock_time_min) external onlyByOwner {

--- a/src/hardhat/contracts/Staking/CommunalFarm.sol
+++ b/src/hardhat/contracts/Staking/CommunalFarm.sol
@@ -573,7 +573,7 @@ contract CommunalFarm is Owned, ReentrancyGuard {
             "Reward period incomplete"
         );
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     function setMultipliers(uint256 _lock_max_multiplier) external onlyByOwner {
@@ -589,7 +589,7 @@ contract CommunalFarm is Owned, ReentrancyGuard {
         lock_time_for_max_multiplier = _lock_time_for_max_multiplier;
         lock_time_min = _lock_time_min;
 
-        emit LockedStakeTimeForMaxMultiplier(lock_time_for_max_multiplier);
+        emit LockedStakeTimeForMaxMultiplier(_lock_time_for_max_multiplier);
         emit LockedStakeMinTime(_lock_time_min);
     }
 

--- a/src/hardhat/contracts/Staking/FRAX3CRV_Curve_FXS_Distributor.sol
+++ b/src/hardhat/contracts/Staking/FRAX3CRV_Curve_FXS_Distributor.sol
@@ -243,7 +243,7 @@ contract Pausable is Owned {
         }
 
         // Let everyone know that our pause state has changed.
-        emit PauseChanged(paused);
+        emit PauseChanged(_paused);
     }
 
     event PauseChanged(bool isPaused);
@@ -580,7 +580,7 @@ contract FRAX3CRV_Curve_FXS_Distributor is IStakingRewards, RewardsDistributionR
             "Reward period incomplete"
         );
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     /* ========== MODIFIERS ========== */

--- a/src/hardhat/contracts/Staking/FraxCrossChainFarm.sol
+++ b/src/hardhat/contracts/Staking/FraxCrossChainFarm.sol
@@ -705,9 +705,9 @@ contract FraxCrossChainFarm is Owned, ReentrancyGuard {
         vefxs_max_multiplier = _vefxs_max_multiplier;
         vefxs_per_frax_for_max_boost = _vefxs_per_frax_for_max_boost;
 
-        emit MaxVeFXSMultiplier(vefxs_max_multiplier);
-        emit LockedStakeMaxMultiplierUpdated(lock_max_multiplier);
-        emit veFXSPerFraxForMaxBoostUpdated(vefxs_per_frax_for_max_boost);
+        emit MaxVeFXSMultiplier(_vefxs_max_multiplier);
+        emit LockedStakeMaxMultiplierUpdated(_lock_max_multiplier);
+        emit veFXSPerFraxForMaxBoostUpdated(_vefxs_per_frax_for_max_boost);
     }
 
     function setLockedStakeTimeForMinAndMaxMultiplier(uint256 _lock_time_for_max_multiplier, uint256 _lock_time_min) external onlyByOwnGov {
@@ -717,7 +717,7 @@ contract FraxCrossChainFarm is Owned, ReentrancyGuard {
         lock_time_for_max_multiplier = _lock_time_for_max_multiplier;
         lock_time_min = _lock_time_min;
 
-        emit LockedStakeTimeForMaxMultiplier(lock_time_for_max_multiplier);
+        emit LockedStakeTimeForMaxMultiplier(_lock_time_for_max_multiplier);
         emit LockedStakeMinTime(_lock_time_min);
     }
 

--- a/src/hardhat/contracts/Staking/FraxCrossChainFarmV2.sol
+++ b/src/hardhat/contracts/Staking/FraxCrossChainFarmV2.sol
@@ -814,9 +814,9 @@ contract FraxCrossChainFarmV2 is Owned, ReentrancyGuard {
         vefxs_max_multiplier = _vefxs_max_multiplier;
         vefxs_per_frax_for_max_boost = _vefxs_per_frax_for_max_boost;
 
-        emit MaxVeFXSMultiplier(vefxs_max_multiplier);
-        emit LockedStakeMaxMultiplierUpdated(lock_max_multiplier);
-        emit veFXSPerFraxForMaxBoostUpdated(vefxs_per_frax_for_max_boost);
+        emit MaxVeFXSMultiplier(_vefxs_max_multiplier);
+        emit LockedStakeMaxMultiplierUpdated(_lock_max_multiplier);
+        emit veFXSPerFraxForMaxBoostUpdated(_vefxs_per_frax_for_max_boost);
     }
 
     function setLockedStakeTimeForMinAndMaxMultiplier(uint256 _lock_time_for_max_multiplier, uint256 _lock_time_min) external onlyByOwnGov {
@@ -826,7 +826,7 @@ contract FraxCrossChainFarmV2 is Owned, ReentrancyGuard {
         lock_time_for_max_multiplier = _lock_time_for_max_multiplier;
         lock_time_min = _lock_time_min;
 
-        emit LockedStakeTimeForMaxMultiplier(lock_time_for_max_multiplier);
+        emit LockedStakeTimeForMaxMultiplier(_lock_time_for_max_multiplier);
         emit LockedStakeMinTime(_lock_time_min);
     }
 

--- a/src/hardhat/contracts/Staking/FraxUniV3Farm_Stable.sol
+++ b/src/hardhat/contracts/Staking/FraxUniV3Farm_Stable.sol
@@ -765,9 +765,9 @@ contract FraxUniV3Farm_Stable is Owned, ReentrancyGuard {
         vefxs_max_multiplier = _vefxs_max_multiplier;
         vefxs_per_frax_for_max_boost = _vefxs_per_frax_for_max_boost;
 
-        emit MaxVeFXSMultiplier(vefxs_max_multiplier);
-        emit LockedNFTMaxMultiplierUpdated(lock_max_multiplier);
-        emit veFXSPctForMaxBoostUpdated(vefxs_per_frax_for_max_boost);
+        emit MaxVeFXSMultiplier(_vefxs_max_multiplier);
+        emit LockedNFTMaxMultiplierUpdated(_lock_max_multiplier);
+        emit veFXSPctForMaxBoostUpdated(_vefxs_per_frax_for_max_boost);
     }
 
     function setLockedNFTTimeForMinAndMaxMultiplier(uint256 _lock_time_for_max_multiplier, uint256 _lock_time_min) external onlyByOwnGov {
@@ -777,7 +777,7 @@ contract FraxUniV3Farm_Stable is Owned, ReentrancyGuard {
         lock_time_for_max_multiplier = _lock_time_for_max_multiplier;
         lock_time_min = _lock_time_min;
 
-        emit LockedNFTTimeForMaxMultiplier(lock_time_for_max_multiplier);
+        emit LockedNFTTimeForMaxMultiplier(_lock_time_for_max_multiplier);
         emit LockedNFTMinTime(_lock_time_min);
     }
 

--- a/src/hardhat/contracts/Staking/StakingRewardsDualV5.sol
+++ b/src/hardhat/contracts/Staking/StakingRewardsDualV5.sol
@@ -612,7 +612,7 @@ contract StakingRewardsDualV5 is Owned, ReentrancyGuard {
             "Reward period incomplete"
         );
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     function setMultipliers(uint256 _lock_max_multiplier, uint256 _vefxs_max_multiplier, uint256 _vefxs_per_frax_for_max_boost) external onlyByOwnGov {
@@ -624,9 +624,9 @@ contract StakingRewardsDualV5 is Owned, ReentrancyGuard {
         vefxs_max_multiplier = _vefxs_max_multiplier;
         vefxs_per_frax_for_max_boost = _vefxs_per_frax_for_max_boost;
 
-        emit MaxVeFXSMultiplier(vefxs_max_multiplier);
-        emit LockedStakeMaxMultiplierUpdated(lock_max_multiplier);
-        emit veFXSPerFraxForMaxBoostUpdated(vefxs_per_frax_for_max_boost);
+        emit MaxVeFXSMultiplier(_vefxs_max_multiplier);
+        emit LockedStakeMaxMultiplierUpdated(_lock_max_multiplier);
+        emit veFXSPerFraxForMaxBoostUpdated(_vefxs_per_frax_for_max_boost);
     }
 
     function setLockedStakeTimeForMinAndMaxMultiplier(uint256 _lock_time_for_max_multiplier, uint256 _lock_time_min) external onlyByOwnGov {
@@ -636,7 +636,7 @@ contract StakingRewardsDualV5 is Owned, ReentrancyGuard {
         lock_time_for_max_multiplier = _lock_time_for_max_multiplier;
         lock_time_min = _lock_time_min;
 
-        emit LockedStakeTimeForMaxMultiplier(lock_time_for_max_multiplier);
+        emit LockedStakeTimeForMaxMultiplier(_lock_time_for_max_multiplier);
         emit LockedStakeMinTime(_lock_time_min);
     }
 

--- a/src/hardhat/contracts/Staking/StakingRewardsMultiGauge.sol
+++ b/src/hardhat/contracts/Staking/StakingRewardsMultiGauge.sol
@@ -833,7 +833,7 @@ contract StakingRewardsMultiGauge is Owned, ReentrancyGuard {
             "Reward period incomplete"
         );
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     function setMultipliers(uint256 _lock_max_multiplier, uint256 _vefxs_max_multiplier, uint256 _vefxs_per_frax_for_max_boost) external onlyByOwner {
@@ -845,9 +845,9 @@ contract StakingRewardsMultiGauge is Owned, ReentrancyGuard {
         vefxs_max_multiplier = _vefxs_max_multiplier;
         vefxs_per_frax_for_max_boost = _vefxs_per_frax_for_max_boost;
 
-        emit MaxVeFXSMultiplier(vefxs_max_multiplier);
-        emit LockedStakeMaxMultiplierUpdated(lock_max_multiplier);
-        emit veFXSPerFraxForMaxBoostUpdated(vefxs_per_frax_for_max_boost);
+        emit MaxVeFXSMultiplier(_vefxs_max_multiplier);
+        emit LockedStakeMaxMultiplierUpdated(_lock_max_multiplier);
+        emit veFXSPerFraxForMaxBoostUpdated(_vefxs_per_frax_for_max_boost);
     }
 
     function setLockedStakeTimeForMinAndMaxMultiplier(uint256 _lock_time_for_max_multiplier, uint256 _lock_time_min) external onlyByOwner {
@@ -857,7 +857,7 @@ contract StakingRewardsMultiGauge is Owned, ReentrancyGuard {
         lock_time_for_max_multiplier = _lock_time_for_max_multiplier;
         lock_time_min = _lock_time_min;
 
-        emit LockedStakeTimeForMaxMultiplier(lock_time_for_max_multiplier);
+        emit LockedStakeTimeForMaxMultiplier(_lock_time_for_max_multiplier);
         emit LockedStakeMinTime(_lock_time_min);
     }
 

--- a/src/hardhat/contracts/Staking/veFXSYieldDistributorV4.sol
+++ b/src/hardhat/contracts/Staking/veFXSYieldDistributorV4.sol
@@ -333,7 +333,7 @@ contract veFXSYieldDistributorV4 is Owned, ReentrancyGuard {
     function setYieldDuration(uint256 _yieldDuration) external onlyByOwnGov {
         require( periodFinish == 0 || block.timestamp > periodFinish, "Previous yield period must be complete before changing the duration for the new period");
         yieldDuration = _yieldDuration;
-        emit YieldDurationUpdated(yieldDuration);
+        emit YieldDurationUpdated(_yieldDuration);
     }
 
     function greylistAddress(address _address) external onlyByOwnGov {

--- a/src/hardhat/old_contracts/Staking/FraxCrossChainFarmSushi.sol
+++ b/src/hardhat/old_contracts/Staking/FraxCrossChainFarmSushi.sol
@@ -653,9 +653,9 @@ contract FraxCrossChainFarmSushi is Owned, ReentrancyGuard {
         vefxs_max_multiplier = _vefxs_max_multiplier;
         vefxs_per_frax_for_max_boost = _vefxs_per_frax_for_max_boost;
 
-        emit MaxVeFXSMultiplier(vefxs_max_multiplier);
-        emit LockedStakeMaxMultiplierUpdated(lock_max_multiplier);
-        emit veFXSPerFraxForMaxBoostUpdated(vefxs_per_frax_for_max_boost);
+        emit MaxVeFXSMultiplier(_vefxs_max_multiplier);
+        emit LockedStakeMaxMultiplierUpdated(_lock_max_multiplier);
+        emit veFXSPerFraxForMaxBoostUpdated(_vefxs_per_frax_for_max_boost);
     }
 
     function setLockedStakeTimeForMinAndMaxMultiplier(uint256 _lock_time_for_max_multiplier, uint256 _lock_time_min) external onlyByOwnGov {
@@ -665,7 +665,7 @@ contract FraxCrossChainFarmSushi is Owned, ReentrancyGuard {
         lock_time_for_max_multiplier = _lock_time_for_max_multiplier;
         lock_time_min = _lock_time_min;
 
-        emit LockedStakeTimeForMaxMultiplier(lock_time_for_max_multiplier);
+        emit LockedStakeTimeForMaxMultiplier(_lock_time_for_max_multiplier);
         emit LockedStakeMinTime(_lock_time_min);
     }
 

--- a/src/hardhat/old_contracts/Staking/FraxUniV3Farm_V2.sol
+++ b/src/hardhat/old_contracts/Staking/FraxUniV3Farm_V2.sol
@@ -985,10 +985,10 @@ contract FraxUniV3Farm_Stable is Owned, ReentrancyGuard {
         vefxs_per_frax_for_max_boost = _vefxs_per_frax_for_max_boost;
         vefxs_boost_scale_factor = _vefxs_boost_scale_factor;
 
-        emit MaxVeFXSMultiplier(vefxs_max_multiplier);
-        emit LockedStakeMaxMultiplierUpdated(lock_max_multiplier);
-        emit veFXSPerFraxForMaxBoostUpdated(vefxs_per_frax_for_max_boost);
-        emit veFXSBoostScaleFactor(vefxs_boost_scale_factor);
+        emit MaxVeFXSMultiplier(_vefxs_max_multiplier);
+        emit LockedStakeMaxMultiplierUpdated(_lock_max_multiplier);
+        emit veFXSPerFraxForMaxBoostUpdated(_vefxs_per_frax_for_max_boost);
+        emit veFXSBoostScaleFactor(_vefxs_boost_scale_factor);
     }
 
     function setLockedStakeTimeForMinAndMaxMultiplier(uint256 _lock_time_for_max_multiplier, uint256 _lock_time_min) external onlyByOwnGov {
@@ -998,7 +998,7 @@ contract FraxUniV3Farm_Stable is Owned, ReentrancyGuard {
         lock_time_for_max_multiplier = _lock_time_for_max_multiplier;
         lock_time_min = _lock_time_min;
 
-        emit LockedStakeTimeForMaxMultiplier(lock_time_for_max_multiplier);
+        emit LockedStakeTimeForMaxMultiplier(_lock_time_for_max_multiplier);
         emit LockedStakeMinTime(_lock_time_min);
     }
 

--- a/src/hardhat/old_contracts/Staking/FraxUniV3Farm_Volatile.sol
+++ b/src/hardhat/old_contracts/Staking/FraxUniV3Farm_Volatile.sol
@@ -746,9 +746,9 @@ contract FraxUniV3Farm_Volatile is Owned, ReentrancyGuard {
         vefxs_max_multiplier = _vefxs_max_multiplier;
         vefxs_per_frax_for_max_boost = _vefxs_per_frax_for_max_boost;
 
-        emit MaxVeFXSMultiplier(vefxs_max_multiplier);
-        emit LockedNFTMaxMultiplierUpdated(lock_max_multiplier);
-        emit veFXSPctForMaxBoostUpdated(vefxs_per_frax_for_max_boost);
+        emit MaxVeFXSMultiplier(_vefxs_max_multiplier);
+        emit LockedNFTMaxMultiplierUpdated(_lock_max_multiplier);
+        emit veFXSPctForMaxBoostUpdated(_vefxs_per_frax_for_max_boost);
     }
 
     function setLockedNFTTimeForMinAndMaxMultiplier(uint256 _lock_time_for_max_multiplier, uint256 _lock_time_min) external onlyByOwnGov {
@@ -758,7 +758,7 @@ contract FraxUniV3Farm_Volatile is Owned, ReentrancyGuard {
         lock_time_for_max_multiplier = _lock_time_for_max_multiplier;
         lock_time_min = _lock_time_min;
 
-        emit LockedNFTTimeForMaxMultiplier(lock_time_for_max_multiplier);
+        emit LockedNFTTimeForMaxMultiplier(_lock_time_for_max_multiplier);
         emit LockedNFTMinTime(_lock_time_min);
     }
 

--- a/src/hardhat/old_contracts/Staking/StakingRewards.sol
+++ b/src/hardhat/old_contracts/Staking/StakingRewards.sol
@@ -370,7 +370,7 @@ contract StakingRewards is IStakingRewards, RewardsDistributionRecipient, Reentr
             "Reward period incomplete"
         );
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     function setMultipliers(uint256 _locked_stake_max_multiplier, uint256 _cr_boost_max_multiplier) external onlyByOwnGov {
@@ -380,8 +380,8 @@ contract StakingRewards is IStakingRewards, RewardsDistributionRecipient, Reentr
         locked_stake_max_multiplier = _locked_stake_max_multiplier;
         cr_boost_max_multiplier = _cr_boost_max_multiplier;
         
-        emit MaxCRBoostMultiplier(cr_boost_max_multiplier);
-        emit LockedStakeMaxMultiplierUpdated(locked_stake_max_multiplier);
+        emit MaxCRBoostMultiplier(_cr_boost_max_multiplier);
+        emit LockedStakeMaxMultiplierUpdated(_locked_stake_max_multiplier);
     }
 
     function setLockedStakeTimeForMinAndMaxMultiplier(uint256 _locked_stake_time_for_max_multiplier, uint256 _locked_stake_min_time) external onlyByOwnGov {
@@ -393,7 +393,7 @@ contract StakingRewards is IStakingRewards, RewardsDistributionRecipient, Reentr
         locked_stake_min_time = _locked_stake_min_time;
         locked_stake_min_time_str = StringHelpers.uint2str(_locked_stake_min_time);
 
-        emit LockedStakeTimeForMaxMultiplier(locked_stake_time_for_max_multiplier);
+        emit LockedStakeTimeForMaxMultiplier(_locked_stake_time_for_max_multiplier);
         emit LockedStakeMinTime(_locked_stake_min_time);
     }
 

--- a/src/hardhat/old_contracts/Staking/StakingRewardsDual.sol
+++ b/src/hardhat/old_contracts/Staking/StakingRewardsDual.sol
@@ -397,7 +397,7 @@ contract StakingRewardsDual is IStakingRewardsDual, Owned, ReentrancyGuard, Paus
             "Reward period incomplete"
         );
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     function setMultipliers(uint256 _locked_stake_max_multiplier, uint256 _cr_boost_max_multiplier) external onlyByOwnGov {
@@ -407,8 +407,8 @@ contract StakingRewardsDual is IStakingRewardsDual, Owned, ReentrancyGuard, Paus
         locked_stake_max_multiplier = _locked_stake_max_multiplier;
         cr_boost_max_multiplier = _cr_boost_max_multiplier;
         
-        emit MaxCRBoostMultiplier(cr_boost_max_multiplier);
-        emit LockedStakeMaxMultiplierUpdated(locked_stake_max_multiplier);
+        emit MaxCRBoostMultiplier(_cr_boost_max_multiplier);
+        emit LockedStakeMaxMultiplierUpdated(_locked_stake_max_multiplier);
     }
 
     function setLockedStakeTimeForMinAndMaxMultiplier(uint256 _locked_stake_time_for_max_multiplier, uint256 _locked_stake_min_time) external onlyByOwnGov {
@@ -420,7 +420,7 @@ contract StakingRewardsDual is IStakingRewardsDual, Owned, ReentrancyGuard, Paus
         locked_stake_min_time = _locked_stake_min_time;
         locked_stake_min_time_str = StringHelpers.uint2str(_locked_stake_min_time);
 
-        emit LockedStakeTimeForMaxMultiplier(locked_stake_time_for_max_multiplier);
+        emit LockedStakeTimeForMaxMultiplier(_locked_stake_time_for_max_multiplier);
         emit LockedStakeMinTime(_locked_stake_min_time);
     }
 

--- a/src/hardhat/old_contracts/Staking/StakingRewardsDualV2.sol
+++ b/src/hardhat/old_contracts/Staking/StakingRewardsDualV2.sol
@@ -548,7 +548,7 @@ contract StakingRewardsDualV2 is IStakingRewardsDual, Owned, ReentrancyGuard, Pa
             "Reward period incomplete"
         );
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     function setMultipliers(uint256 _locked_stake_max_multiplier, uint256 _cr_boost_max_multiplier) external onlyByOwnGov {
@@ -558,8 +558,8 @@ contract StakingRewardsDualV2 is IStakingRewardsDual, Owned, ReentrancyGuard, Pa
         locked_stake_max_multiplier = _locked_stake_max_multiplier;
         cr_boost_max_multiplier = _cr_boost_max_multiplier;
         
-        emit MaxCRBoostMultiplier(cr_boost_max_multiplier);
-        emit LockedStakeMaxMultiplierUpdated(locked_stake_max_multiplier);
+        emit MaxCRBoostMultiplier(_cr_boost_max_multiplier);
+        emit LockedStakeMaxMultiplierUpdated(_locked_stake_max_multiplier);
     }
 
     function setLockedStakeTimeForMinAndMaxMultiplier(uint256 _locked_stake_time_for_max_multiplier, uint256 _locked_stake_min_time) external onlyByOwnGov {
@@ -571,7 +571,7 @@ contract StakingRewardsDualV2 is IStakingRewardsDual, Owned, ReentrancyGuard, Pa
         locked_stake_min_time = _locked_stake_min_time;
         locked_stake_min_time_str = StringHelpers.uint2str(_locked_stake_min_time);
 
-        emit LockedStakeTimeForMaxMultiplier(locked_stake_time_for_max_multiplier);
+        emit LockedStakeTimeForMaxMultiplier(_locked_stake_time_for_max_multiplier);
         emit LockedStakeMinTime(_locked_stake_min_time);
     }
 

--- a/src/hardhat/old_contracts/Staking/StakingRewardsDualV3.sol
+++ b/src/hardhat/old_contracts/Staking/StakingRewardsDualV3.sol
@@ -594,7 +594,7 @@ contract StakingRewardsDualV3 is Owned, ReentrancyGuard {
             "Reward period incomplete"
         );
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     function setMultipliers(uint256 _lock_max_multiplier, uint256 _vefxs_max_multiplier, uint256 _vefxs_per_frax_for_max_boost) external onlyByOwnGov {
@@ -606,9 +606,9 @@ contract StakingRewardsDualV3 is Owned, ReentrancyGuard {
         vefxs_max_multiplier = _vefxs_max_multiplier;
         vefxs_per_frax_for_max_boost = _vefxs_per_frax_for_max_boost;
 
-        emit MaxVeFXSMultiplier(vefxs_max_multiplier);
-        emit LockedStakeMaxMultiplierUpdated(lock_max_multiplier);
-        emit veFXSPerFraxForMaxBoostUpdated(vefxs_per_frax_for_max_boost);
+        emit MaxVeFXSMultiplier(_vefxs_max_multiplier);
+        emit LockedStakeMaxMultiplierUpdated(_lock_max_multiplier);
+        emit veFXSPerFraxForMaxBoostUpdated(_vefxs_per_frax_for_max_boost);
     }
 
     function setLockedStakeTimeForMinAndMaxMultiplier(uint256 _lock_time_for_max_multiplier, uint256 _lock_time_min) external onlyByOwnGov {
@@ -618,7 +618,7 @@ contract StakingRewardsDualV3 is Owned, ReentrancyGuard {
         lock_time_for_max_multiplier = _lock_time_for_max_multiplier;
         lock_time_min = _lock_time_min;
 
-        emit LockedStakeTimeForMaxMultiplier(lock_time_for_max_multiplier);
+        emit LockedStakeTimeForMaxMultiplier(_lock_time_for_max_multiplier);
         emit LockedStakeMinTime(_lock_time_min);
     }
 

--- a/src/hardhat/old_contracts/Staking/StakingRewardsDualV4.sol
+++ b/src/hardhat/old_contracts/Staking/StakingRewardsDualV4.sol
@@ -585,7 +585,7 @@ contract StakingRewardsDualV4 is Owned, ReentrancyGuard {
             "Reward period incomplete"
         );
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     function setMultipliers(uint256 _lock_max_multiplier, uint256 _vefxs_max_multiplier, uint256 _vefxs_per_frax_for_max_boost) external onlyByOwnGov {
@@ -597,9 +597,9 @@ contract StakingRewardsDualV4 is Owned, ReentrancyGuard {
         vefxs_max_multiplier = _vefxs_max_multiplier;
         vefxs_per_frax_for_max_boost = _vefxs_per_frax_for_max_boost;
 
-        emit MaxVeFXSMultiplier(vefxs_max_multiplier);
-        emit LockedStakeMaxMultiplierUpdated(lock_max_multiplier);
-        emit veFXSPerFraxForMaxBoostUpdated(vefxs_per_frax_for_max_boost);
+        emit MaxVeFXSMultiplier(_vefxs_max_multiplier);
+        emit LockedStakeMaxMultiplierUpdated(_lock_max_multiplier);
+        emit veFXSPerFraxForMaxBoostUpdated(_vefxs_per_frax_for_max_boost);
     }
 
     function setLockedStakeTimeForMinAndMaxMultiplier(uint256 _lock_time_for_max_multiplier, uint256 _lock_time_min) external onlyByOwnGov {
@@ -609,7 +609,7 @@ contract StakingRewardsDualV4 is Owned, ReentrancyGuard {
         lock_time_for_max_multiplier = _lock_time_for_max_multiplier;
         lock_time_min = _lock_time_min;
 
-        emit LockedStakeTimeForMaxMultiplier(lock_time_for_max_multiplier);
+        emit LockedStakeTimeForMaxMultiplier(_lock_time_for_max_multiplier);
         emit LockedStakeMinTime(_lock_time_min);
     }
 

--- a/src/hardhat/old_contracts/Staking/veFXSYieldDistributor.sol
+++ b/src/hardhat/old_contracts/Staking/veFXSYieldDistributor.sol
@@ -255,7 +255,7 @@ contract veFXSYieldDistributor is Owned, ReentrancyGuard {
     function setYieldDuration(uint256 _yieldDuration) external onlyByOwnGov {
         require(periodFinish == 0 || block.timestamp > periodFinish, "Previous yield period must be complete before changing the duration for the new period");
         yieldDuration = _yieldDuration;
-        emit YieldDurationUpdated(yieldDuration);
+        emit YieldDurationUpdated(_yieldDuration);
     }
 
     function initializeDefault() external onlyByOwnGov {

--- a/src/hardhat/old_contracts/Staking/veFXSYieldDistributorV2.sol
+++ b/src/hardhat/old_contracts/Staking/veFXSYieldDistributorV2.sol
@@ -284,7 +284,7 @@ contract veFXSYieldDistributorV2 is Owned, ReentrancyGuard {
             "Previous yield period must be complete before changing the duration for the new period"
         );
         yieldDuration = _yieldDuration;
-        emit YieldDurationUpdated(yieldDuration);
+        emit YieldDurationUpdated(_yieldDuration);
     }
 
     function initializeDefault() external onlyByOwnGov {

--- a/src/hardhat/old_contracts/Staking/veFXSYieldDistributorV3.sol
+++ b/src/hardhat/old_contracts/Staking/veFXSYieldDistributorV3.sol
@@ -294,7 +294,7 @@ contract veFXSYieldDistributorV3 is Owned, ReentrancyGuard {
     function setYieldDuration(uint256 _yieldDuration) external onlyByOwnGov {
         require( periodFinish == 0 || block.timestamp > periodFinish, "Previous yield period must be complete before changing the duration for the new period");
         yieldDuration = _yieldDuration;
-        emit YieldDurationUpdated(yieldDuration);
+        emit YieldDurationUpdated(_yieldDuration);
     }
 
     function initializeDefault() external onlyByOwnGov {

--- a/src/hardhat/old_contracts/__BSC/AnyswapV4ERC20/AnyswapV4ERC20.sol
+++ b/src/hardhat/old_contracts/__BSC/AnyswapV4ERC20/AnyswapV4ERC20.sol
@@ -229,7 +229,7 @@ contract AnyswapV4ERC20 is IAnyswapV3ERC20 {
         require(newVault != address(0), "AnyswapV3ERC20: address(0x0)");
         pendingVault = newVault;
         delayVault = block.timestamp + delay;
-        emit LogChangeVault(vault, pendingVault, delayVault);
+        emit LogChangeVault(vault, newVault, delayVault);
         return true;
     }
 
@@ -237,7 +237,7 @@ contract AnyswapV4ERC20 is IAnyswapV3ERC20 {
         require(newVault != address(0), "AnyswapV3ERC20: address(0x0)");
         pendingVault = newVault;
         delayVault = block.timestamp + delay;
-        emit LogChangeMPCOwner(vault, pendingVault, delayVault);
+        emit LogChangeMPCOwner(vault, newVault, delayVault);
         return true;
     }
 

--- a/src/hardhat/old_contracts/__BSC/Staking/FraxFarmBSC_Dual_V5.sol
+++ b/src/hardhat/old_contracts/__BSC/Staking/FraxFarmBSC_Dual_V5.sol
@@ -523,7 +523,7 @@ contract FraxFarmBSC_Dual_V5 is Owned, ReentrancyGuard {
             "Reward period incomplete"
         );
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     function setMultipliers(uint256 _lock_max_multiplier) external onlyByOwnGov {
@@ -531,7 +531,7 @@ contract FraxFarmBSC_Dual_V5 is Owned, ReentrancyGuard {
 
         lock_max_multiplier = _lock_max_multiplier;
 
-        emit LockedStakeMaxMultiplierUpdated(lock_max_multiplier);
+        emit LockedStakeMaxMultiplierUpdated(_lock_max_multiplier);
     }
 
     function setLockedStakeTimeForMinAndMaxMultiplier(uint256 _lock_time_for_max_multiplier, uint256 _lock_time_min) external onlyByOwnGov {
@@ -541,7 +541,7 @@ contract FraxFarmBSC_Dual_V5 is Owned, ReentrancyGuard {
         lock_time_for_max_multiplier = _lock_time_for_max_multiplier;
         lock_time_min = _lock_time_min;
 
-        emit LockedStakeTimeForMaxMultiplier(lock_time_for_max_multiplier);
+        emit LockedStakeTimeForMaxMultiplier(_lock_time_for_max_multiplier);
         emit LockedStakeMinTime(_lock_time_min);
     }
 

--- a/src/hardhat/old_contracts/__BSC/Staking/MigratableFarmBSC.sol
+++ b/src/hardhat/old_contracts/__BSC/Staking/MigratableFarmBSC.sol
@@ -527,7 +527,7 @@ contract MigratableFarmBSC is Owned, ReentrancyGuard, Pausable {
             "Reward period incomplete"
         );
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     function setMultipliers(uint256 _locked_stake_max_multiplier) external onlyByOwnGov {
@@ -535,7 +535,7 @@ contract MigratableFarmBSC is Owned, ReentrancyGuard, Pausable {
 
         locked_stake_max_multiplier = _locked_stake_max_multiplier;
         
-        emit LockedStakeMaxMultiplierUpdated(locked_stake_max_multiplier);
+        emit LockedStakeMaxMultiplierUpdated(_locked_stake_max_multiplier);
     }
 
     function setLockedStakeTimeForMinAndMaxMultiplier(uint256 _locked_stake_time_for_max_multiplier, uint256 _locked_stake_min_time) external onlyByOwnGov {
@@ -546,7 +546,7 @@ contract MigratableFarmBSC is Owned, ReentrancyGuard, Pausable {
 
         locked_stake_min_time = _locked_stake_min_time;
 
-        emit LockedStakeTimeForMaxMultiplier(locked_stake_time_for_max_multiplier);
+        emit LockedStakeTimeForMaxMultiplier(_locked_stake_time_for_max_multiplier);
         emit LockedStakeMinTime(_locked_stake_min_time);
     }
 


### PR DESCRIPTION
Hi, we are a research group on programming languages and software engineering. We recently have conducted a systematic study about Solidity event usage, evolution, and impact, and we are attempting to build a tool to improve the practice of Solidity event use based on our findings. We have tried our prototype tool on some of the most popular GitHub Solidity repositories, and for your repository, we find a potential optimization of gas consumption arisen from event use.

The point is that when we use emit operation to store the value of a certain variable, `local memory type variable` would be preferable to `storage type (state) variable` if they hold the same value. The reason is that an extra SLOAD operation would be needed to access the variable if it is storage type, and the SLOAD operation costs 800 gas.

For your repository, we find that several event uses can be improved.