### PR TITLE
Add address code length check to onLockRecieved

### DIFF
--- a/src/hardhat/contracts/Staking/FraxUnifiedFarm_ERC20_V2.sol
+++ b/src/hardhat/contracts/Staking/FraxUnifiedFarm_ERC20_V2.sol
@@ -811,14 +811,21 @@ contract FraxUnifiedFarm_ERC20_V2 is FraxUnifiedFarmTemplate_V2 {
             receiver_lock_index
         );
 
-        // call the receiver with the destination lockedStake to verify receiving is ok
-        if (ILockReceiverV2(addrs[1]).onLockReceived(
-            addrs[0], 
-            addrs[1], 
-            receiver_lock_index, 
-            ""
-        ) != ILockReceiverV2.onLockReceived.selector) revert InvalidReceiver(); //0xc42d8b95) revert InvalidReceiver();
 
+        // call the receiver with the destination lockedStake to verify receiving is ok
+        // if (ILockReceiverV2(addrs[1]).onLockReceived(
+        //     addrs[0], 
+        //     addrs[1], 
+        //     receiver_lock_index, 
+        //     ""
+        // ) != ILockReceiverV2.onLockReceived.selector) revert InvalidReceiver(); //0xc42d8b95) revert InvalidReceiver();
+        if (addrs[1].code.length > 0) {
+            require(ILockReceiverV2(addrs[1]).beforeLockTransfer(addrs[0], addrs[1], receiver_lock_index, "") 
+                == 
+                ILockReceiverV2.beforeLockTransfer.selector
+            );
+        }
+        
         return (sender_lock_index, receiver_lock_index);
     }
 


### PR DESCRIPTION
Didn't check whether the receiver address is a contract or not, causing it to fail for instances of transfer to EOA.