### PR TITLE
Correct event emission in `_stakeLocked`

### DIFF
--- a/src/hardhat/contracts/Staking/FraxUnifiedFarm_ERC20_V2.sol
+++ b/src/hardhat/contracts/Staking/FraxUnifiedFarm_ERC20_V2.sol
@@ -532,7 +532,7 @@ contract FraxUnifiedFarm_ERC20_V2 is FraxUnifiedFarmTemplate_V2 {
         // Update liquidities
         _updateLiqAmts(staker_address, liquidity, true);
 
-        emit StakeLocked(staker_address, liquidity, secs, lockedStakes[staker_address].length, source_address);
+        emit StakeLocked(staker_address, liquidity, secs, lockedStakes[staker_address].length - 1, source_address);
 
         return lockedStakes[staker_address].length - 1;
     }


### PR DESCRIPTION
Change the event emit value to match the name of the value for the event emitted during `_stakeLocked` function. It's emitting the number of stakes the user has instead of the new locked stake index. Added ` - 1` to the value being emitted to get it to match with the name of the parameter for the event.