### PR TITLE
Update bridge function in  IOptimismMintableERC20.sol

### DIFF
--- a/src/hardhat/contracts/ERC20/IOptimismMintableERC20.sol
+++ b/src/hardhat/contracts/ERC20/IOptimismMintableERC20.sol
@@ -10,7 +10,7 @@ import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol
 interface IOptimismMintableERC20 is IERC165 {
     function remoteToken() external view returns (address);
 
-    function bridge() external returns (address);
+    function bridge() external view returns (address);
 
     function mint(address _to, uint256 _amount) external;
 


### PR DESCRIPTION
`bridge()` function is currently only set to  `external`, we can minimize gas costs by also setting it to `view` as it is a read-only function.